### PR TITLE
Fix eval and evalsha with keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69c054daeca01bc1bee4af75b04dffa3458d6702cb7a74c2f38518c130fb624"
+checksum = "3eeb1fe3fc011cde97315f370bc88e4db3c23b08709a04915921e02b1d363b20"
 dependencies = [
  "bytes",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 crc16 = "0.4"
 futures = "0.3"
 rand = "0.7"
-redis = { version = "0.14", features = ["tokio-rt-core"] }
+redis = { version = "0.15", features = ["tokio-rt-core"] }
 tokio = { version = "0.2", features = ["time"] }
 log = "0.4"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ where
                 }
                 self.retry = self.retry.saturating_add(1);
 
-                if let Some(error_code) = err.extension_error_code() {
+                if let Some(error_code) = err.code() {
                     if error_code == "MOVED" || error_code == "ASK" {
                         // Refresh slots and request again.
                         self.info.excludes.clear();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ impl<C> CmdArg<C> {
     }
 
     fn slot(&self) -> Option<u16> {
-        fn get_cmd_arg<'a>(cmd: &'a Cmd, arg_num: usize) -> Option<&'a [u8]> {
+        fn get_cmd_arg(cmd: &Cmd, arg_num: usize) -> Option<&[u8]> {
             cmd.args_iter().nth(arg_num).and_then(|arg| match arg {
                 redis::Arg::Simple(arg) => Some(arg),
                 redis::Arg::Cursor => None,

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -209,7 +209,7 @@ fn tryagain_exhaust_retries() {
 
     assert_eq!(
         result.map_err(|err| err.to_string()),
-        Err("TRYAGAIN: mock".to_string())
+        Err("An error was signalled by the server: mock".to_string())
     );
     assert_eq!(requests.load(atomic::Ordering::SeqCst), 3);
 }


### PR DESCRIPTION
I was able to get eval and evalsha working, however, I was unable to use the Script() method of executing a lua script. The reason is that it uses SCRIPT LOAD, which must be sent to all masters. I did create a unittest for that which is #[ignore].

Also included is update to use redis-rs version 0.15