### PR TITLE
fix: Don't loop forever if the inner MultiplexedConnection shutsdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
     - run: cargo build --verbose
     - run: cargo doc --verbose
     - name: Run tests
-      run: '(./start_cluster.sh &) ; cargo test --verbose'
+      run: '(./start_cluster.sh &); sleep 10; cargo test --verbose'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
+
+[[package]]
 name = "async-trait"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,11 +620,12 @@ dependencies = [
 name = "redis_cluster_async"
 version = "0.6.1-alpha.0"
 dependencies = [
+ "anyhow",
  "crc16",
  "env_logger",
  "futures",
- "lazy_static",
  "log",
+ "once_cell",
  "pin-project-lite",
  "proptest",
  "rand 0.8.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ tokio = { version = "1", features = ["time"] }
 log = "0.4"
 
 [dev-dependencies]
-lazy_static = "1"
+anyhow = "1"
+once_cell = "1"
 tokio = { version = "1", features = ["macros", "full"] }
 env_logger = "0.8"
 proptest = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -719,7 +719,7 @@ where
                     }
                 }
                 ConnectionState::PollComplete => {
-                    let mut error = None;
+                    let mut connection_error = None;
 
                     if !self.pending_requests.is_empty() {
                         let mut pending_requests = mem::take(&mut self.pending_requests);
@@ -760,17 +760,14 @@ where
                                     },
                                 }));
                             }
-                            Next::Err {
-                                request,
-                                error: err,
-                            } => {
-                                error = Some(err);
+                            Next::Err { request, error } => {
+                                connection_error = Some(error);
                                 self.pending_requests.push(request);
                             }
                         }
                     }
 
-                    if let Some(err) = error {
+                    if let Some(err) = connection_error {
                         trace!("Recovering {}", err);
                         self.state = ConnectionState::Recover(Box::pin(self.refresh_slots()))
                     } else if self.in_flight_requests.is_empty() {

--- a/start_cluster.sh
+++ b/start_cluster.sh
@@ -7,4 +7,4 @@ exec docker run \
     --name redis-cluster \
     -e "IP=127.0.0.1" \
     -p 7000:7000 -p 7001:7001 -p 7002:7002 -p 7003:7003 -p 7004:7004 -p 7005:7005 \
-    grokzen/redis-cluster:latest
+    grokzen/redis-cluster:6.0.0

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -5,6 +5,7 @@ use std::{
 
 use {
     futures::future,
+    once_cell::sync::Lazy,
     redis_cluster_async::{
         redis::{
             aio::ConnectionLike, cmd, parse_redis_value, IntoConnectionInfo, RedisFuture,
@@ -17,10 +18,7 @@ use {
 
 type Handler = Arc<dyn Fn(&redis::Cmd, u16) -> Result<(), RedisResult<Value>> + Send + Sync>;
 
-lazy_static::lazy_static! {
-    static ref HANDLERS: RwLock<HashMap<String, Handler>>
-        = Default::default();
-}
+static HANDLERS: Lazy<RwLock<HashMap<String, Handler>>> = Lazy::new(Default::default);
 
 #[derive(Clone)]
 pub struct MockConnection {


### PR DESCRIPTION
If the inner `MultiplexedConnection`(s) ends up shutting down it is possible that this crate ends up looping forever in `poll_flush`. Once a connection ends up failing the cluster connection ends up in a `Recover` state where it will attempt to re-establish the slot mapping and reconnecting any failed connections. However, as the error during the reconnect attempt was ignored and the attempt  was immediately retried it was possible to end trying to reconnect forever despite the connection no longer being in use.

This fixes both of these problems, errors are now reported back to (a) caller when a reconnect fails so that the caller can do their own recovery (the internal recovery is about recovering from slots being moved, not connection failures). `poll_close` has also been changed to ensure that requests are drained so it can return `Ready` and shutdown the task driving 
the cluster connection.

It is quite possible that the issue was exacerbated by https://github.com/mitsuhiko/redis-rs/pull/502 which fixed an issue where `MultiplexedConnection` would return errors instead of closing the channel completely. So while the recovery loops here could happen even before that change they would be "tighter" after it as the recovery would error immediately on detecting that the receive end of the `mpsc` channel used in `MultiplexedConnection` were closed instead of having to wait for an error response.