### PR TITLE
fix: Ensure that the connection map get updated on missing connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "redis_cluster_async"
-version = "0.6.3-alpha.0"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "crc16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_cluster_async"
-version = "0.6.3-alpha.0"
+version = "0.6.2"
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 keywords = ["redis", "cluster", "database", "async"]
 description = "Async redis cluster driver for Rust."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -576,11 +576,8 @@ where
 
     fn get_connection(&self, slot: u16) -> impl Future<Output = (String, C)> + 'static {
         if let Some((_, addr)) = self.slots.range(&slot..).next() {
-            if self.connections.contains_key(addr) {
-                return future::Either::Left(future::ready((
-                    addr.clone(),
-                    self.connections.get(addr).unwrap().clone(),
-                )));
+            if let Some(conn) = self.connections.get(addr) {
+                return future::Either::Left(future::ready((addr.clone(), conn.clone())));
             }
 
             // Create new connection.


### PR DESCRIPTION
This was omitted out of the initial translation of this which could
cause the connection map to always be out of date if new addresses were
added as they were newer added to the map