### PR TITLE
feat: add readonly flag; add choose random slave

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ impl Client {
 
     /// Set readonly flag which tells that the client is willing to read
     /// Default: false
-    pub fn readonly(&mut self, readonly: bool) -> &mut Self {
+    pub fn readonly(mut self, readonly: bool) -> Self {
         self.readonly = readonly;
         self
     }


### PR DESCRIPTION
Hi. I found that GET requests always come to the master, and while they should go to the slaves in most cases. I think that behavior is not good, because the peculiarity of the cluster is lost when distributing the load