### PR TITLE
Fix key positions for XGROUP, XREAD, and XREADGROUP commands

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,7 @@ impl<C> CmdArg<C> {
 
         fn slot_for_command(cmd: &Cmd) -> Option<u16> {
             match get_cmd_arg(cmd, 0) {
-                Some(b"EVAL") | Some(b"EVALSHA") | Some(b"XGROUP") => {
+                Some(b"EVAL") | Some(b"EVALSHA") => {
                     get_cmd_arg(cmd, 2).and_then(|key_count_bytes| {
                         let key_count_res = std::str::from_utf8(key_count_bytes)
                             .ok()
@@ -239,6 +239,7 @@ impl<C> CmdArg<C> {
                         })
                     })
                 }
+                Some(b"XGROUP") => get_cmd_arg(cmd, 2).map(|key| slot_for_key(key)),
                 Some(b"XREAD") | Some(b"XREADGROUP") => {
                     let pos = position(cmd, b"STREAMS")?;
                     get_cmd_arg(cmd, pos + 1).map(slot_for_key)
@@ -1120,6 +1121,7 @@ where
                         } else {
                             return None;
                         };
+
                         match &password {
                             Some(pw) => Some(format!("redis://:{}@{}:{}", pw, ip, port)),
                             None => Some(format!("redis://{}:{}", ip, port)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ use pin_project_lite::pin_project;
 use rand::seq::IteratorRandom;
 use rand::thread_rng;
 use redis::{
-    aio::ConnectionLike, Cmd, ConnectionAddr, ConnectionInfo, ErrorKind, IntoConnectionInfo,
+    aio::ConnectionLike, Arg, Cmd, ConnectionAddr, ConnectionInfo, ErrorKind, IntoConnectionInfo,
     RedisError, RedisFuture, RedisResult, Value,
 };
 use tokio::sync::{mpsc, oneshot};
@@ -214,9 +214,17 @@ impl<C> CmdArg<C> {
                 redis::Arg::Cursor => None,
             })
         }
+
+        fn position(cmd: &Cmd, candidate: &[u8]) -> Option<usize> {
+            cmd.args_iter().position(|arg| match arg {
+                Arg::Simple(arg) => arg.eq_ignore_ascii_case(candidate),
+                _ => false,
+            })
+        }
+
         fn slot_for_command(cmd: &Cmd) -> Option<u16> {
             match get_cmd_arg(cmd, 0) {
-                Some(b"EVAL") | Some(b"EVALSHA") => {
+                Some(b"EVAL") | Some(b"EVALSHA") | Some(b"XGROUP") => {
                     get_cmd_arg(cmd, 2).and_then(|key_count_bytes| {
                         let key_count_res = std::str::from_utf8(key_count_bytes)
                             .ok()
@@ -230,6 +238,10 @@ impl<C> CmdArg<C> {
                             }
                         })
                     })
+                }
+                Some(b"XREAD") | Some(b"XREADGROUP") => {
+                    let pos = position(cmd, b"STREAMS")?;
+                    get_cmd_arg(cmd, pos + 1).map(slot_for_key)
                 }
                 Some(b"SCRIPT") => {
                     // TODO need to handle sending to all masters


### PR DESCRIPTION
The wrong key positions were used which was breaking the sharding key.