### PR TITLE
fix splice addr bug when password contains any special character

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,7 @@ dependencies = [
  "rand 0.8.4",
  "redis",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rand = { version = "0.8", default-features = false, features = ["std", "std_rng"
 redis = { version = "0.21", features = ["tokio-comp"] }
 tokio = { version = "1", features = ["time"] }
 log = "0.4"
+url = "2.2.2"
 
 [dev-dependencies]
 anyhow = "1"


### PR DESCRIPTION
Fix: When the password contains special characters, such as @#. The addr spliced out with format like ("redis://:{}@{}:{}", pw, host, port) will cause the get_password method parse url failed. 

This PR will escape the special characters in the password part of the url, like [url standard](https://url.spec.whatwg.org/#path-percent-encode-set)