### PR TITLE
chore: update redis version to 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ crc16 = "0.4"
 futures = "0.3"
 pin-project-lite = "0.2"
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
-redis = { version = "0.21", features = ["tokio-comp"] }
+redis = { version = "0.22", features = ["tokio-comp"] }
 tokio = { version = "1", features = ["time"] }
 log = "0.4"
 


### PR DESCRIPTION
- redis_cluster_async 0.7.0 is not compatible with redis 0.22