### PR TITLE
Build proper connection string on refresh_slots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
     - run: cargo build --verbose
     - run: cargo doc --verbose
     - name: Run tests
-      run: '(./start_cluster.sh &); sleep 10; cargo test --verbose'
+      run: '(./start_cluster.sh &); sleep 10; cargo test --verbose -- --test-threads=1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
     - run: cargo build --verbose
     - run: cargo doc --verbose
     - name: Run tests
-      run: '(./start_cluster.sh &); sleep 10; cargo test --verbose -- --test-threads=1'
+      run: '(./start_cluster.sh &); sleep 20; cargo test --verbose -- --test-threads=1'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1165,7 +1165,7 @@ where
                             return None;
                         };
 
-                        let ip : &str = if ip != "" {&ip} else {&host.as_ref().unwrap()};
+                        let ip = if ip != "" {&ip} else {&host.as_ref().unwrap()};
 
                         Some(build_connection_string(
                             username.as_deref(),

--- a/start_cluster.sh
+++ b/start_cluster.sh
@@ -1,10 +1,20 @@
 #!/bin/sh
 
-exec docker run \
+docker run \
     --rm \
     --init \
     --tty \
     --name redis-cluster \
+    -d \
     -e "IP=127.0.0.1" \
     -p 7000:7000 -p 7001:7001 -p 7002:7002 -p 7003:7003 -p 7004:7004 -p 7005:7005 \
-    grokzen/redis-cluster:6.0.0
+    grokzen/redis-cluster:6.0.0;
+
+sleep 10;
+
+redis-cli -h 127.0.0.1 -p 7000 -c ACL SETUSER client-user allkeys +@all ON \>redis-password;
+redis-cli -h 127.0.0.1 -p 7001 -c ACL SETUSER client-user allkeys +@all ON \>redis-password;
+redis-cli -h 127.0.0.1 -p 7002 -c ACL SETUSER client-user allkeys +@all ON \>redis-password;
+redis-cli -h 127.0.0.1 -p 7003 -c ACL SETUSER client-user allkeys +@all ON \>redis-password;
+redis-cli -h 127.0.0.1 -p 7004 -c ACL SETUSER client-user allkeys +@all ON \>redis-password;
+redis-cli -h 127.0.0.1 -p 7005 -c ACL SETUSER client-user allkeys +@all ON \>redis-password;

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -23,6 +23,7 @@ use redis_cluster_async::{
 };
 
 const REDIS_URL: &str = "redis://127.0.0.1:7000/";
+const AUTHENTICATED_REDIS_URL: &str = "redis://client-user:redis-password@127.0.0.1:7000/";
 
 pub struct RedisProcess;
 pub struct RedisLock(MutexGuard<'static, RedisProcess>);
@@ -268,6 +269,29 @@ fn proptests() {
 #[test]
 fn basic_failover() {
     test_failover(&mut FailoverEnv::new(), 10, 123);
+}
+
+#[tokio::test]
+async fn test_refresh_slot() {
+    let client = Client::open(vec![AUTHENTICATED_REDIS_URL])
+        .expect("Expect being able to build a Redis cluster client.");
+    let mut connection = client
+        .get_connection()
+        .await
+        .expect("Expect being able to get a cluster connection.");
+
+    // Query a range of keys to make sure we hit all hashslots in all masters.
+    // This is to ensure that we hit all masters, which will assert that we are able to
+    // build valid connection strings against all masters,
+    // i.e., `refresh_slots` works since we only provide the URL of one master in the initial list of nodes.
+    for key in 0..20000 {
+        let res: Option<String> = cmd("GET")
+            .arg(key.to_string())
+            .query_async(&mut connection)
+            .await
+            .expect("Expect being to query for key.");
+        assert!(res.is_none());
+    }
 }
 
 struct FailoverEnv {


### PR DESCRIPTION
If `username` and `password` are provided in the initial connection strings, we should use them to build connection strings on `get_slots`. Currently, when using username and password to log in to the cluster, we would fail to create connection string on `get_slots` because we drop the `username` and `password` when building the connection strings. 
Note: I changed running test to be single thread to ensure tests don't interfere with each other. 